### PR TITLE
fix: make organization payload optional

### DIFF
--- a/src/types/payload.ts
+++ b/src/types/payload.ts
@@ -223,7 +223,7 @@ export const PayloadSchema = Type.Object({
   label: Type.Optional(LabelSchema),
   sender: UserSchema,
   repository: RepositorySchema,
-  organization: OrganizationSchema,
+  organization: Type.Optional(OrganizationSchema),
   installation: Type.Optional(InstallationSchema),
 });
 


### PR DESCRIPTION
I've added the bot to one of my github repos and on adding a label to an issue I got the following error:
```
INFO (event): Payload schema validation failed!!!
    id: "b54e95b0-9cc5-11ed-8c7c-723ed247b6ad"
WARN (event):
    0: {
      "instancePath": "",
      "schemaPath": "#/required",
      "keyword": "required",
      "params": {
        "missingProperty": "organization"
      },
      "message": "must have required property 'organization'"
    }
    id: "b54e95b0-9cc5-11ed-8c7c-723ed247b6ad"
```

So this PR makes the `organization` property optional